### PR TITLE
build: add fragmenter script and specify version

### DIFF
--- a/scripts/fragment.js
+++ b/scripts/fragment.js
@@ -4,6 +4,7 @@ const fs = require('fs');
 const execute = async () => {
   try {
     const result = await fragmenter.pack({
+      version: require('./fragmenter_version').version,
       baseDir: './build',
       outDir: './build-modules',
       packOptions: { splitFileSize: 102_760_448, keepCompleteModulesAfterSplit: false },

--- a/scripts/fragmenter_version.js
+++ b/scripts/fragmenter_version.js
@@ -1,0 +1,18 @@
+const buildInfo = require('./git_build_info').getGitBuildInfo();
+const packageInfo = require('../package.json');
+
+let version;
+if (buildInfo?.tag && /^v\d+\.\d+\.\d+$/.test(buildInfo.tag)) {
+  version = buildInfo.tag;
+} else {
+  const hash = buildInfo?.shortHash;
+
+  if (!hash) {
+    console.error('[!] buildInfo.shortHash is falsy');
+    process.exit(-1);
+  }
+
+  version = buildInfo.shortHash;
+}
+
+module.exports = { version };


### PR DESCRIPTION
## Summary of Changes

- Add fragmenter_version.js script and specify version in fragmenter scripts (for installer)
- Improve release version name by tag name (v1.0.0)

## Testing instructions

- Not needed.

Scripts by @Benjozork