### PR TITLE
fix: attempt to fix memory leaks by recreating kernels when needed

### DIFF
--- a/apps/server/src/terrain/processing/maphandler.ts
+++ b/apps/server/src/terrain/processing/maphandler.ts
@@ -69,6 +69,49 @@ export class MapHandler {
 
   private aircraftStatus: AircraftStatus = null;
 
+  private createUploadWorldMapToGPUKernel(): IKernelRunShortcut {
+    return this.gpu.createKernel(uploadTextureData, {
+      argumentTypes: { texture: 'Array', width: 'Integer' },
+      dynamicArguments: true,
+      dynamicOutput: false,
+      pipeline: true,
+      immutable: false,
+      tactic: 'speed',
+    });
+  }
+
+  private createExtractLocalElevationMapKernel(): IKernelRunShortcut {
+    return this.gpu
+      .createKernel(createLocalElevationMap, {
+        dynamicArguments: true,
+        dynamicOutput: false,
+        pipeline: true,
+        immutable: false,
+        tactic: 'speed',
+      })
+      .setConstants<LocalElevationMapConstants>({
+        unknownElevation: UnknownElevation,
+        invalidElevation: InvalidElevation,
+      })
+      .setFunctions([deg2rad, degreesPerPixel, normalizeHeading, rad2deg, projectWgs84, wgs84toPixelCoordinate]);
+  }
+
+  private createExtractElevationProfileKernel(): IKernelRunShortcut {
+    return this.gpu
+      .createKernel(createElevationProfile, {
+        dynamicArguments: true,
+        dynamicOutput: false,
+        pipeline: true,
+        immutable: false,
+        tactic: 'speed',
+      })
+      .setConstants<ElevationProfileConstants>({
+        unknownElevation: UnknownElevation,
+        invalidElevation: InvalidElevation,
+      })
+      .setFunctions([deg2rad, rad2deg, bearingWgs84, distanceWgs84, projectWgs84, wgs84toPixelCoordinate]);
+  }
+
   private cleanupMemory(): void {
     this.worldmap.resetInternalData();
     if (this.cachedElevationData.gpuData !== null) {
@@ -105,43 +148,12 @@ export class MapHandler {
 
   private createKernels(): void {
     // register kernel to upload the map data
-    this.uploadWorldMapToGPU = this.gpu.createKernel(uploadTextureData, {
-      argumentTypes: { texture: 'Array', width: 'Integer' },
-      dynamicArguments: true,
-      dynamicOutput: true,
-      pipeline: true,
-      immutable: false,
-      tactic: 'speed',
-    });
+    this.uploadWorldMapToGPU = this.createUploadWorldMapToGPUKernel();
 
     // register kernel to create the local map
-    this.extractLocalElevationMap = this.gpu
-      .createKernel(createLocalElevationMap, {
-        dynamicArguments: true,
-        dynamicOutput: true,
-        pipeline: true,
-        immutable: false,
-        tactic: 'speed',
-      })
-      .setConstants<LocalElevationMapConstants>({
-        unknownElevation: UnknownElevation,
-        invalidElevation: InvalidElevation,
-      })
-      .setFunctions([deg2rad, degreesPerPixel, normalizeHeading, rad2deg, projectWgs84, wgs84toPixelCoordinate]);
+    this.extractLocalElevationMap = this.createExtractLocalElevationMapKernel();
 
-    this.extractElevationProfile = this.gpu
-      .createKernel(createElevationProfile, {
-        dynamicArguments: true,
-        dynamicOutput: true,
-        pipeline: true,
-        immutable: false,
-        tactic: 'speed',
-      })
-      .setConstants<ElevationProfileConstants>({
-        unknownElevation: UnknownElevation,
-        invalidElevation: InvalidElevation,
-      })
-      .setFunctions([deg2rad, rad2deg, bearingWgs84, distanceWgs84, projectWgs84, wgs84toPixelCoordinate]);
+    this.extractElevationProfile = this.createExtractElevationProfileKernel();
   }
 
   private async readTerrainMap(): Promise<TerrainMap | undefined> {
@@ -297,7 +309,15 @@ export class MapHandler {
       this.worldMapMetadata.width = worldWidth;
       this.worldMapMetadata.height = worldHeight;
 
-      this.uploadWorldMapToGPU = this.uploadWorldMapToGPU.setOutput([worldWidth, worldHeight]);
+      if (
+        this.uploadWorldMapToGPU.output === null ||
+        this.uploadWorldMapToGPU.output[0] !== worldWidth ||
+        this.uploadWorldMapToGPU.output[1] !== worldHeight
+      ) {
+        if (this.uploadWorldMapToGPU !== null) this.uploadWorldMapToGPU.destroy();
+        this.uploadWorldMapToGPU = this.createUploadWorldMapToGPUKernel().setOutput([worldWidth, worldHeight]);
+      }
+
       this.cachedElevationData.gpuData = this.uploadWorldMapToGPU(
         this.cachedElevationData.cpuData,
         worldWidth,
@@ -386,7 +406,11 @@ export class MapHandler {
       this.extractLocalElevationMap.output[0] !== config.mapWidth ||
       this.extractLocalElevationMap.output[1] !== config.mapHeight
     ) {
-      this.extractLocalElevationMap = this.extractLocalElevationMap.setOutput([config.mapWidth, config.mapHeight]);
+      if (this.extractLocalElevationMap !== null) this.extractLocalElevationMap.destroy();
+      this.extractLocalElevationMap = this.createExtractLocalElevationMapKernel().setOutput([
+        config.mapWidth,
+        config.mapHeight,
+      ]);
     }
 
     let metresPerPixel = Math.round(
@@ -433,7 +457,8 @@ export class MapHandler {
       return null;
 
     if (this.extractElevationProfile.output === null || this.extractElevationProfile.output[0] !== profileWidth) {
-      this.extractElevationProfile = this.extractElevationProfile.setOutput([profileWidth]);
+      if (this.extractElevationProfile !== null) this.extractElevationProfile.destroy();
+      this.extractElevationProfile = this.createExtractElevationProfileKernel().setOutput([profileWidth]);
     }
 
     // create the local elevation map

--- a/apps/server/src/terrain/processing/navigationdisplayrenderer.ts
+++ b/apps/server/src/terrain/processing/navigationdisplayrenderer.ts
@@ -126,10 +126,25 @@ export class NavigationDisplayRenderer {
       })
       .setOutput([NavigationDisplayMaxPixelWidth, NavigationDisplayMaxPixelHeight]);
 
-    this.localHistogram = this.gpu
+    this.localHistogram = this.createLocalHistogramKernel();
+
+    this.histogram = this.gpu
+      .createKernel(createElevationHistogram, {
+        dynamicArguments: true,
+        pipeline: true,
+        immutable: false,
+      })
+      .setLoopMaxIterations(500)
+      .setOutput([HistogramBinCount]);
+
+    this.renderer = this.createRendererKernel();
+  }
+
+  private createLocalHistogramKernel(): IKernelRunShortcut {
+    return this.gpu
       .createKernel(createLocalElevationHistogram, {
         dynamicArguments: true,
-        dynamicOutput: true,
+        dynamicOutput: false,
         pipeline: true,
         immutable: false,
       })
@@ -143,20 +158,13 @@ export class NavigationDisplayRenderer {
         binCount: HistogramBinCount,
         patchSize: HistogramPatchSize,
       });
+  }
 
-    this.histogram = this.gpu
-      .createKernel(createElevationHistogram, {
-        dynamicArguments: true,
-        pipeline: true,
-        immutable: false,
-      })
-      .setLoopMaxIterations(500)
-      .setOutput([HistogramBinCount]);
-
-    this.renderer = this.gpu
+  private createRendererKernel(): IKernelRunShortcut {
+    return this.gpu
       .createKernel(renderNavigationDisplay, {
         dynamicArguments: true,
-        dynamicOutput: true,
+        dynamicOutput: false,
         pipeline: false,
         immutable: false,
       })
@@ -286,7 +294,8 @@ export class NavigationDisplayRenderer {
     const patchCount = patchesInX * patchesInY;
 
     if (this.localHistogram.output === null || this.localHistogram.output[1] !== patchCount) {
-      this.localHistogram = this.localHistogram.setOutput([HistogramBinCount, patchCount]);
+      this.localHistogram.destroy();
+      this.localHistogram = this.createLocalHistogramKernel().setOutput([HistogramBinCount, patchCount]);
     }
 
     const localHistograms = this.localHistogram(
@@ -415,7 +424,8 @@ export class NavigationDisplayRenderer {
       this.renderer.output[0] !== this.configuration.mapWidth * RenderingColorChannelCount ||
       this.renderer.output[1] !== this.configuration.mapHeight + 1
     ) {
-      this.renderer = this.renderer.setOutput([
+      this.renderer.destroy();
+      this.renderer = this.createRendererKernel().setOutput([
         this.configuration.mapWidth * RenderingColorChannelCount,
         this.configuration.mapHeight + 1,
       ]);


### PR DESCRIPTION
As noticed by @frayien and @tracernz creating a GPU kernel with dynamicOutput might create memory leaks each time "setOutput" is called. This PR disables dynamicOutput and recreates the kernels if the output sizes change.