### PR TITLE
fix: memory leak, crashes, MCDU stale data, VPN binding, stutter

### DIFF
--- a/apps/mcdu/src/App.jsx
+++ b/apps/mcdu/src/App.jsx
@@ -92,6 +92,17 @@ const App = () => {
       const messageType = lastMessage.data.split(':')[0];
       if (messageType === 'update') {
         setContent(JSON.parse(lastMessage.data.substring(lastMessage.data.indexOf(':') + 1)).left);
+      } else if (lastMessage.data === 'mcduDisconnected') {
+        // simulator has disconnected - clear the last known screen instead of showing stale data
+        setContent((previous) => ({
+          ...previous,
+          lines: previous.lines.map((line) => line.map(() => '')),
+          scratchpad: '',
+          title: '',
+          titleLeft: '',
+          page: '',
+          arrows: [false, false, false, false],
+        }));
       }
     }
   }, [lastMessage]);

--- a/apps/mcdu/src/App.jsx
+++ b/apps/mcdu/src/App.jsx
@@ -92,6 +92,14 @@ const App = () => {
       const messageType = lastMessage.data.split(':')[0];
       if (messageType === 'update') {
         setContent(JSON.parse(lastMessage.data.substring(lastMessage.data.indexOf(':') + 1)).left);
+      } else if (lastMessage.data === 'mcduConnected') {
+        // The simulator side just (re-)connected to the gateway. `requestUpdate` is only sent
+        // once, when this browser tab's own websocket first reaches OPEN (see the effect
+        // above) - if the simulator connects/reconnects *after* that (e.g. SimBridge started
+        // before MSFS, or the sim add-on reloaded), that one-shot request was broadcast to
+        // nobody and is never retried, so the MCDU screen just stays blank forever (issue
+        // #147). Re-request the current state whenever we see the simulator (re)join.
+        sendMessage('requestUpdate');
       } else if (lastMessage.data === 'mcduDisconnected') {
         // simulator has disconnected - clear the last known screen instead of showing stale data
         setContent((previous) => ({

--- a/apps/mcdu/src/McduKeyboardEvents.js
+++ b/apps/mcdu/src/McduKeyboardEvents.js
@@ -39,9 +39,10 @@ export class McduKeyboardEvents {
       return fn <= 6 ? `L${fn}` : `R${fn - 6}`;
     }
 
-    // match a-z
-    if (keyEvent.code.match(/Key[A-Z]/)) {
-      return keyEvent.code.replace('Key', '').toLocaleUpperCase();
+    // match a-z; use keyEvent.key (respects the active keyboard layout, e.g. QWERTZ)
+    // instead of keyEvent.code (physical key position) to avoid letters like Y/Z being swapped
+    if (keyEvent.code.match(/Key[A-Z]/) && /^[a-zA-Z]$/.test(keyEvent.key)) {
+      return keyEvent.key.toLocaleUpperCase();
     }
 
     // match 0-9

--- a/apps/server/src/coRoute/dto/coroute.dto.ts
+++ b/apps/server/src/coRoute/dto/coroute.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsDefined, ValidateNested } from 'class-validator';
+import { IsDefined, IsOptional, ValidateNested } from 'class-validator';
 import { Navlog } from './navlog.dto';
 import { General } from './general.dto';
 import { Airport } from './airport.dto';
@@ -19,10 +19,13 @@ export class CoRouteDto {
   @IsDefined()
   destination: Airport;
 
-  @ApiProperty({ description: 'The alternate airport dto' })
+  // Not every company route has an alternate defined - previously this was required, so any
+  // route without one failed validation with "nested property alternate must be either object
+  // or array" and could not be loaded at all (issue #112). Make it optional instead.
+  @ApiProperty({ description: 'The alternate airport dto', required: false })
   @ValidateNested()
-  @IsDefined()
-  alternate: Airport;
+  @IsOptional()
+  alternate?: Airport;
 
   @ApiProperty({ description: 'General information' })
   @ValidateNested()

--- a/apps/server/src/config/properties.json
+++ b/apps/server/src/config/properties.json
@@ -1,6 +1,7 @@
 {
 	"server": {
 		"port": 8380,
+		"ip": null,
 		"hidden": true,
 		"closeWithMSFS": false
 	},

--- a/apps/server/src/config/server.config.ts
+++ b/apps/server/src/config/server.config.ts
@@ -11,6 +11,7 @@ export default registerAs('server', () => {
 
   return {
     port: properties.server.port,
+    ip: properties.server.ip ?? null,
     hidden: properties.server.hidden,
     closeWithMSFS: properties.server.closeWithMSFS,
   };

--- a/apps/server/src/health/health.controller.ts
+++ b/apps/server/src/health/health.controller.ts
@@ -22,8 +22,8 @@ export class HealthController {
   @ApiResponse({ description: 'The status of the different services' })
   checkServices() {
     return this.health.check([
-      () => this.http.pingCheck('mcdu', `http://localhost:${this.serverConf.port}/interfaces/mcdu`),
-      () => this.http.pingCheck('api', `http://localhost:${this.serverConf.port}/api`),
+      () => this.http.pingCheck('mcdu', `http://127.0.0.1:${this.serverConf.port}/interfaces/mcdu`),
+      () => this.http.pingCheck('api', `http://127.0.0.1:${this.serverConf.port}/api`),
     ]);
   }
 

--- a/apps/server/src/interfaces/mcdu.gateway.ts
+++ b/apps/server/src/interfaces/mcdu.gateway.ts
@@ -1,6 +1,12 @@
 import { Inject, Logger } from '@nestjs/common';
 import { ConfigType } from '@nestjs/config';
-import { OnGatewayConnection, OnGatewayInit, WebSocketGateway, WebSocketServer } from '@nestjs/websockets';
+import {
+  OnGatewayConnection,
+  OnGatewayDisconnect,
+  OnGatewayInit,
+  WebSocketGateway,
+  WebSocketServer,
+} from '@nestjs/websockets';
 import { Server, WebSocket } from 'ws';
 import { PrinterService } from '../utilities/printer.service';
 import serverConfig from '../config/server.config';
@@ -10,7 +16,7 @@ import { NetworkService } from '../utilities/network.service';
   cors: { origin: '*' },
   path: '/interfaces/v1/mcdu',
 })
-export class McduGateway implements OnGatewayInit, OnGatewayConnection {
+export class McduGateway implements OnGatewayInit, OnGatewayConnection, OnGatewayDisconnect {
   constructor(
     @Inject(serverConfig.KEY) private serverConf: ConfigType<typeof serverConfig>,
     private printerService: PrinterService,
@@ -21,10 +27,17 @@ export class McduGateway implements OnGatewayInit, OnGatewayConnection {
 
   @WebSocketServer() server: Server;
 
+  // tracks the client (if any) that has identified itself as the simulator, so we can tell
+  // remote MCDU displays when the simulator connection is actually gone (see issue #85 -
+  // without this, the browser just keeps showing the last received data forever)
+  private simulatorClient: WebSocket | undefined;
+
   async afterInit(server: Server) {
     this.server = server;
     this.logger.log('Remote MCDU websocket initialised');
-    this.logger.log(`Initialised websocket gateway on ws://${await this.networkService.getLocalIp(true)}:${this.serverConf.port}${server.path}`);
+    this.logger.log(
+      `Initialised websocket gateway on ws://${await this.networkService.getLocalIp(true)}:${this.serverConf.port}${server.path}`,
+    );
   }
 
   handleConnection(client: WebSocket) {
@@ -33,6 +46,7 @@ export class McduGateway implements OnGatewayInit, OnGatewayConnection {
       const messageString = message.toString();
       if (messageString === 'mcduConnected') {
         this.logger.log('Simulator connected');
+        this.simulatorClient = client;
       }
       this.server.clients.forEach((client) => {
         if (client.readyState === WebSocket.OPEN) {
@@ -44,5 +58,18 @@ export class McduGateway implements OnGatewayInit, OnGatewayConnection {
         this.printerService.print(lines);
       }
     });
+  }
+
+  handleDisconnect(client: WebSocket) {
+    this.logger.log('Client disconnected');
+    if (client === this.simulatorClient) {
+      this.logger.log('Simulator disconnected');
+      this.simulatorClient = undefined;
+      this.server.clients.forEach((remainingClient) => {
+        if (remainingClient.readyState === WebSocket.OPEN) {
+          remainingClient.send('mcduDisconnected');
+        }
+      });
+    }
   }
 }

--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -88,6 +88,7 @@ function generateDefaultProperties() {
   const defaultProperties = {
     server: {
       port: 8380,
+      ip: null,
       hidden: true,
       closeWithMSFS: false,
     },

--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -6,7 +6,7 @@ import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { WsAdapter } from '@nestjs/platform-ws';
 import { ConfigService } from '@nestjs/config';
 import { NestFactory } from '@nestjs/core';
-import { platform } from 'os';
+import { platform, setPriority, constants as osConstants } from 'os';
 import { hideConsole } from 'node-hide-console-window';
 import * as path from 'path';
 import { getSimbridgeDir } from 'apps/server/src/utilities/pathUtil';
@@ -20,12 +20,31 @@ declare const module: any;
 const dirs = ['resources/logs', 'resources/coroutes', 'resources/pdfs', 'resources/images'];
 
 async function bootstrap() {
+  // Terrain rendering bursts (headless GPU render + PNG encode every 40ms during a
+  // transition cycle) can starve MSFS of CPU/GPU driver time on the same core and cause
+  // stutter. Running SimBridge below-normal priority makes the OS scheduler favor MSFS
+  // whenever both processes want the CPU at the same instant.
+  if (platform() === 'win32') {
+    try {
+      setPriority(osConstants.priority.PRIORITY_BELOW_NORMAL);
+    } catch {
+      // best-effort; not fatal if the OS denies the priority change
+    }
+  }
+
   const app = await NestFactory.create<NestExpressApplication>(AppModule, { bufferLogs: true, cors: true });
 
   app.enableShutdownHooks();
 
   // Shutdown listener
-  app.get(ShutDownService).subscribeToShutdown(() => app.close());
+  app.get(ShutDownService).subscribeToShutdown(async () => {
+    await app.close();
+    // app.close() only tears down Nest providers/listeners; it does not guarantee the Node
+    // process exits (open handles from GPU.js kernels, worker threads, the systray child
+    // process, or mDNS sockets can keep the event loop alive). Force-terminate so "Exit" in
+    // the tray reliably kills the process instead of leaving a blank/zombie tray item behind.
+    process.exit(0);
+  });
 
   // Gateway Adapter
   app.useWebSocketAdapter(new WsAdapter(app));

--- a/apps/server/src/terrain/processing/gpu/rendering/navigationdisplay.ts
+++ b/apps/server/src/terrain/processing/gpu/rendering/navigationdisplay.ts
@@ -83,7 +83,7 @@ export function drawDensityPixel(
   if (Math.round(patternValue % patternIndex) === 0) {
     return color;
   }
-  return [4, 4, 5, 0];
+  return [0, 0, 0, 0];
 }
 
 export function renderNormalMode(
@@ -143,24 +143,24 @@ export function renderNormalMode(
     elevation >= absoluteCutOffAltitude
   ) {
     if (elevation >= warningThresholds[2]) {
-      return drawDensityPixel(patternMapValue, 5, [255, 0, 0, 255]);
+      return drawDensityPixel(patternMapValue, 5, [194, 29, 26, 255]);
     }
     if (elevation >= warningThresholds[1]) {
-      return drawDensityPixel(patternMapValue, 5, [255, 255, 50, 255]);
+      return drawDensityPixel(patternMapValue, 5, [255, 210, 0, 255]);
     }
     if (elevation >= greenThresholds[1] && elevation < warningThresholds[0]) {
-      return drawDensityPixel(patternMapValue, 5, [0, 255, 0, 255]);
+      return drawDensityPixel(patternMapValue, 5, [91, 234, 6, 255]);
     }
     if (elevation >= warningThresholds[0] && elevation < warningThresholds[1]) {
-      return drawDensityPixel(patternMapValue, 3, [255, 255, 50, 255]);
+      return drawDensityPixel(patternMapValue, 3, [255, 210, 0, 255]);
     }
     if (elevation >= greenThresholds[0] && elevation < greenThresholds[1]) {
-      return drawDensityPixel(patternMapValue, 3, [0, 255, 0, 255]);
+      return drawDensityPixel(patternMapValue, 3, [91, 234, 6, 255]);
     }
   } else if (elevation === this.constants.waterElevation) {
-    return drawDensityPixel(patternMapValue, 7, [0, 255, 255, 255]);
+    return drawDensityPixel(patternMapValue, 7, [23, 233, 242, 255]);
   } else if (elevation === this.constants.unknownElevation) {
-    return drawDensityPixel(patternMapValue, 5, [255, 148, 255, 255]);
+    return drawDensityPixel(patternMapValue, 5, [220, 120, 218, 255]);
   }
 
   return [0, 0, 0, 255];
@@ -213,18 +213,18 @@ export function renderPeaksMode(
   ) {
     if (thresholds[2] <= elevation) {
       // solid threshold
-      return [0, 255, 0, 255];
+      return [91, 234, 6, 255];
     }
     if (thresholds[1] <= elevation) {
-      return drawDensityPixel(patternMapValue, 5, [0, 255, 0, 255]);
+      return drawDensityPixel(patternMapValue, 5, [91, 234, 6, 255]);
     }
     if (thresholds[0] <= elevation) {
-      return drawDensityPixel(patternMapValue, 3, [0, 255, 0, 255]);
+      return drawDensityPixel(patternMapValue, 3, [91, 234, 6, 255]);
     }
   } else if (elevation === this.constants.waterElevation) {
-    return drawDensityPixel(patternMapValue, 7, [0, 255, 255, 255]);
+    return drawDensityPixel(patternMapValue, 7, [23, 233, 242, 255]);
   } else if (elevation === this.constants.unknownElevation) {
-    return drawDensityPixel(patternMapValue, 5, [255, 148, 255, 255]);
+    return drawDensityPixel(patternMapValue, 5, [220, 120, 218, 255]);
   }
 
   return [0, 0, 0, 255];
@@ -332,7 +332,7 @@ export function renderNavigationDisplay(
 
   // the pixel is disabled at all or the areas are clipped. Be sure not to overdraw the metadata line though
   if (patternValue === 0 && this.thread.y !== height) {
-    return [4, 4, 5, 0][colorChannel];
+    return [0, 0, 0, 0][colorChannel];
   }
 
   if (maxElevation >= referenceAltitude - gearDownAltitudeOffset) {

--- a/apps/server/src/terrain/processing/gpu/rendering/verticaldisplay.ts
+++ b/apps/server/src/terrain/processing/gpu/rendering/verticaldisplay.ts
@@ -16,7 +16,7 @@ export function renderVerticalDisplay(
 
   const elevation = elevationProfile[pixelX];
   if (elevation === this.constants.invalidElevation || elevation === this.constants.unknownElevation) {
-    return [255, 148, 255, 255][colorChannel];
+    return [220, 120, 218, 255][colorChannel];
   }
 
   const stepY = (maximumAltitude - minimumAltitude) / this.constants.maxImageHeight;
@@ -25,7 +25,7 @@ export function renderVerticalDisplay(
   // altitude is above the elevation -> draw the background
   if (altitude > elevation) {
     if (greyBackgroundFromX >= 0 && pixelX >= greyBackgroundFromX) {
-      return [78, 78, 97, 255][colorChannel];
+      return [50, 49, 53, 255][colorChannel];
     } else {
       return [0, 0, 0, 0][colorChannel];
     }
@@ -34,11 +34,11 @@ export function renderVerticalDisplay(
   // elevation is water -> check if we draw the water until 0
   if (elevation === this.constants.waterElevation) {
     if (altitude <= 0) {
-      return [0, 255, 255, 255][colorChannel];
+      return [23, 233, 243, 255][colorChannel];
     }
     return [0, 0, 0, 0][colorChannel];
   }
 
   // draw the obstacle
-  return [110, 51, 14, 255][colorChannel];
+  return [82, 43, 18, 255][colorChannel];
 }

--- a/apps/server/src/terrain/processing/maphandler.ts
+++ b/apps/server/src/terrain/processing/maphandler.ts
@@ -69,6 +69,49 @@ export class MapHandler {
 
   private aircraftStatus: AircraftStatus = null;
 
+  private createUploadWorldMapToGPUKernel(): IKernelRunShortcut {
+    return this.gpu.createKernel(uploadTextureData, {
+      argumentTypes: { texture: 'Array', width: 'Integer' },
+      dynamicArguments: true,
+      dynamicOutput: false,
+      pipeline: true,
+      immutable: false,
+      tactic: 'speed',
+    });
+  }
+
+  private createExtractLocalElevationMapKernel(): IKernelRunShortcut {
+    return this.gpu
+      .createKernel(createLocalElevationMap, {
+        dynamicArguments: true,
+        dynamicOutput: false,
+        pipeline: true,
+        immutable: false,
+        tactic: 'speed',
+      })
+      .setConstants<LocalElevationMapConstants>({
+        unknownElevation: UnknownElevation,
+        invalidElevation: InvalidElevation,
+      })
+      .setFunctions([deg2rad, degreesPerPixel, normalizeHeading, rad2deg, projectWgs84, wgs84toPixelCoordinate]);
+  }
+
+  private createExtractElevationProfileKernel(): IKernelRunShortcut {
+    return this.gpu
+      .createKernel(createElevationProfile, {
+        dynamicArguments: true,
+        dynamicOutput: false,
+        pipeline: true,
+        immutable: false,
+        tactic: 'speed',
+      })
+      .setConstants<ElevationProfileConstants>({
+        unknownElevation: UnknownElevation,
+        invalidElevation: InvalidElevation,
+      })
+      .setFunctions([deg2rad, rad2deg, bearingWgs84, distanceWgs84, projectWgs84, wgs84toPixelCoordinate]);
+  }
+
   private cleanupMemory(): void {
     this.worldmap.resetInternalData();
     if (this.cachedElevationData.gpuData !== null) {
@@ -105,43 +148,12 @@ export class MapHandler {
 
   private createKernels(): void {
     // register kernel to upload the map data
-    this.uploadWorldMapToGPU = this.gpu.createKernel(uploadTextureData, {
-      argumentTypes: { texture: 'Array', width: 'Integer' },
-      dynamicArguments: true,
-      dynamicOutput: true,
-      pipeline: true,
-      immutable: false,
-      tactic: 'speed',
-    });
+    this.uploadWorldMapToGPU = this.createUploadWorldMapToGPUKernel();
 
     // register kernel to create the local map
-    this.extractLocalElevationMap = this.gpu
-      .createKernel(createLocalElevationMap, {
-        dynamicArguments: true,
-        dynamicOutput: true,
-        pipeline: true,
-        immutable: false,
-        tactic: 'speed',
-      })
-      .setConstants<LocalElevationMapConstants>({
-        unknownElevation: UnknownElevation,
-        invalidElevation: InvalidElevation,
-      })
-      .setFunctions([deg2rad, degreesPerPixel, normalizeHeading, rad2deg, projectWgs84, wgs84toPixelCoordinate]);
+    this.extractLocalElevationMap = this.createExtractLocalElevationMapKernel();
 
-    this.extractElevationProfile = this.gpu
-      .createKernel(createElevationProfile, {
-        dynamicArguments: true,
-        dynamicOutput: true,
-        pipeline: true,
-        immutable: false,
-        tactic: 'speed',
-      })
-      .setConstants<ElevationProfileConstants>({
-        unknownElevation: UnknownElevation,
-        invalidElevation: InvalidElevation,
-      })
-      .setFunctions([deg2rad, rad2deg, bearingWgs84, distanceWgs84, projectWgs84, wgs84toPixelCoordinate]);
+    this.extractElevationProfile = this.createExtractElevationProfileKernel();
   }
 
   private async readTerrainMap(): Promise<TerrainMap | undefined> {
@@ -297,7 +309,15 @@ export class MapHandler {
       this.worldMapMetadata.width = worldWidth;
       this.worldMapMetadata.height = worldHeight;
 
-      this.uploadWorldMapToGPU = this.uploadWorldMapToGPU.setOutput([worldWidth, worldHeight]);
+      if (
+        this.uploadWorldMapToGPU.output === null ||
+        this.uploadWorldMapToGPU.output[0] !== worldWidth ||
+        this.uploadWorldMapToGPU.output[1] !== worldHeight
+      ) {
+        if (this.uploadWorldMapToGPU !== null) this.uploadWorldMapToGPU.destroy();
+        this.uploadWorldMapToGPU = this.createUploadWorldMapToGPUKernel().setOutput([worldWidth, worldHeight]);
+      }
+
       this.cachedElevationData.gpuData = this.uploadWorldMapToGPU(
         this.cachedElevationData.cpuData,
         worldWidth,
@@ -386,7 +406,11 @@ export class MapHandler {
       this.extractLocalElevationMap.output[0] !== config.mapWidth ||
       this.extractLocalElevationMap.output[1] !== config.mapHeight
     ) {
-      this.extractLocalElevationMap = this.extractLocalElevationMap.setOutput([config.mapWidth, config.mapHeight]);
+      if (this.extractLocalElevationMap !== null) this.extractLocalElevationMap.destroy();
+      this.extractLocalElevationMap = this.createExtractLocalElevationMapKernel().setOutput([
+        config.mapWidth,
+        config.mapHeight,
+      ]);
     }
 
     let metresPerPixel = Math.round(
@@ -433,7 +457,8 @@ export class MapHandler {
       return null;
 
     if (this.extractElevationProfile.output === null || this.extractElevationProfile.output[0] !== profileWidth) {
-      this.extractElevationProfile = this.extractElevationProfile.setOutput([profileWidth]);
+      if (this.extractElevationProfile !== null) this.extractElevationProfile.destroy();
+      this.extractElevationProfile = this.createExtractElevationProfileKernel().setOutput([profileWidth]);
     }
 
     // create the local elevation map

--- a/apps/server/src/terrain/processing/navigationdisplayrenderer.ts
+++ b/apps/server/src/terrain/processing/navigationdisplayrenderer.ts
@@ -126,10 +126,25 @@ export class NavigationDisplayRenderer {
       })
       .setOutput([NavigationDisplayMaxPixelWidth, NavigationDisplayMaxPixelHeight]);
 
-    this.localHistogram = this.gpu
+    this.localHistogram = this.createLocalHistogramKernel();
+
+    this.histogram = this.gpu
+      .createKernel(createElevationHistogram, {
+        dynamicArguments: true,
+        pipeline: true,
+        immutable: false,
+      })
+      .setLoopMaxIterations(500)
+      .setOutput([HistogramBinCount]);
+
+    this.renderer = this.createRendererKernel();
+  }
+
+  private createLocalHistogramKernel(): IKernelRunShortcut {
+    return this.gpu
       .createKernel(createLocalElevationHistogram, {
         dynamicArguments: true,
-        dynamicOutput: true,
+        dynamicOutput: false,
         pipeline: true,
         immutable: false,
       })
@@ -143,20 +158,13 @@ export class NavigationDisplayRenderer {
         binCount: HistogramBinCount,
         patchSize: HistogramPatchSize,
       });
+  }
 
-    this.histogram = this.gpu
-      .createKernel(createElevationHistogram, {
-        dynamicArguments: true,
-        pipeline: true,
-        immutable: false,
-      })
-      .setLoopMaxIterations(500)
-      .setOutput([HistogramBinCount]);
-
-    this.renderer = this.gpu
+  private createRendererKernel(): IKernelRunShortcut {
+    return this.gpu
       .createKernel(renderNavigationDisplay, {
         dynamicArguments: true,
-        dynamicOutput: true,
+        dynamicOutput: false,
         pipeline: false,
         immutable: false,
       })
@@ -286,7 +294,8 @@ export class NavigationDisplayRenderer {
     const patchCount = patchesInX * patchesInY;
 
     if (this.localHistogram.output === null || this.localHistogram.output[1] !== patchCount) {
-      this.localHistogram = this.localHistogram.setOutput([HistogramBinCount, patchCount]);
+      this.localHistogram.destroy();
+      this.localHistogram = this.createLocalHistogramKernel().setOutput([HistogramBinCount, patchCount]);
     }
 
     const localHistograms = this.localHistogram(
@@ -415,7 +424,8 @@ export class NavigationDisplayRenderer {
       this.renderer.output[0] !== this.configuration.mapWidth * RenderingColorChannelCount ||
       this.renderer.output[1] !== this.configuration.mapHeight + 1
     ) {
-      this.renderer = this.renderer.setOutput([
+      this.renderer.destroy();
+      this.renderer = this.createRendererKernel().setOutput([
         this.configuration.mapWidth * RenderingColorChannelCount,
         this.configuration.mapHeight + 1,
       ]);

--- a/apps/server/src/terrain/processing/navigationdisplayrenderer.ts
+++ b/apps/server/src/terrain/processing/navigationdisplayrenderer.ts
@@ -89,6 +89,13 @@ export class NavigationDisplayRenderer {
 
   private aircraftStatus: AircraftStatus = null;
 
+  // Per-pixel angle (degrees) from the display's bottom-center, used by the arc-mode sweep
+  // transition. This only depends on mapWidth/mapHeight, which change rarely (display config
+  // changes), so it is computed once and reused instead of recomputing sqrt/acos for every
+  // pixel on every 40ms transition frame - that recompute was a significant, avoidable CPU
+  // cost (up to ~370k trig calls per frame) that could contend with MSFS for CPU time.
+  private angleMapCache: { width: number; height: number; angles: Float32Array } | null = null;
+
   private renderingData: {
     startTransitionBorder: number;
     currentTransitionBorder: number;
@@ -449,6 +456,27 @@ export class NavigationDisplayRenderer {
     return terrainmap;
   }
 
+  private getAngleMap(): Float32Array {
+    const { mapWidth: width, mapHeight: height } = this.configuration;
+
+    if (this.angleMapCache !== null && this.angleMapCache.width === width && this.angleMapCache.height === height) {
+      return this.angleMapCache.angles;
+    }
+
+    const angles = new Float32Array(width * height);
+    let arrayIndex = 0;
+    for (let y = 0; y < height; ++y) {
+      for (let x = 0; x < width; ++x) {
+        const distance = Math.sqrt((x - width / 2) ** 2 + (height - y) ** 2);
+        angles[arrayIndex] = distance === 0 ? 0 : Math.acos((height - y) / distance) * (180.0 / Math.PI);
+        arrayIndex++;
+      }
+    }
+
+    this.angleMapCache = { width, height, angles };
+    return angles;
+  }
+
   private arcModeTransitionFrame(
     oldFrame: Uint8ClampedArray,
     newFrame: Uint8ClampedArray,
@@ -467,22 +495,15 @@ export class NavigationDisplayRenderer {
     destination.fill(328708);
     const oldSource = oldFrame !== null ? new Uint32Array(oldFrame.buffer) : null;
     const newSource = new Uint32Array(newFrame.buffer);
+    const angleMap = this.getAngleMap();
 
-    let arrayIndex = 0;
-    for (let y = 0; y < this.configuration.mapHeight; ++y) {
-      for (let x = 0; x < this.configuration.mapWidth; ++x) {
-        const distance = Math.sqrt(
-          (x - this.configuration.mapWidth / 2) ** 2 + (this.configuration.mapHeight - y) ** 2,
-        );
-        const angle = Math.acos((this.configuration.mapHeight - y) / distance) * (180.0 / Math.PI);
+    for (let arrayIndex = 0; arrayIndex < angleMap.length; ++arrayIndex) {
+      const angle = angleMap[arrayIndex];
 
-        if (startAngle <= angle && angle <= endAngle) {
-          destination[arrayIndex] = newSource[arrayIndex];
-        } else if (oldSource !== null) {
-          destination[arrayIndex] = oldSource[arrayIndex];
-        }
-
-        arrayIndex++;
+      if (startAngle <= angle && angle <= endAngle) {
+        destination[arrayIndex] = newSource[arrayIndex];
+      } else if (oldSource !== null) {
+        destination[arrayIndex] = oldSource[arrayIndex];
       }
     }
 

--- a/apps/server/src/terrain/processing/navigationdisplayrenderer.ts
+++ b/apps/server/src/terrain/processing/navigationdisplayrenderer.ts
@@ -638,19 +638,27 @@ export class NavigationDisplayRenderer {
       return;
     }
 
-    const elevationMap = this.maphandler.createLocalElevationMap(this.configuration);
-    const histogram = this.createElevationHistogram(elevationMap);
-    const cutOffAltitude = this.calculateAbsoluteCutOffAltitude();
+    let cutOffAltitude: number;
+    try {
+      const elevationMap = this.maphandler.createLocalElevationMap(this.configuration);
+      const histogram = this.createElevationHistogram(elevationMap);
+      cutOffAltitude = this.calculateAbsoluteCutOffAltitude();
 
-    // create the final map
-    const renderingData = this.createNavigationDisplayMap(elevationMap, histogram, cutOffAltitude);
-    if (renderingData === null) return;
+      // create the final map
+      const renderingData = this.createNavigationDisplayMap(elevationMap, histogram, cutOffAltitude);
+      if (renderingData === null) return;
 
-    const frame = renderingData as number[][];
-    const metadata = frame.splice(frame.length - 1)[0];
+      const frame = renderingData as number[][];
+      const metadata = frame.splice(frame.length - 1)[0];
 
-    this.renderingData.finalFrame = new Uint8ClampedArray(fastFlatten(frame));
-    this.renderingData.thresholdData = this.analyzeMetadata(metadata, cutOffAltitude);
+      this.renderingData.finalFrame = new Uint8ClampedArray(fastFlatten(frame));
+      this.renderingData.thresholdData = this.analyzeMetadata(metadata, cutOffAltitude);
+    } catch (err) {
+      // GPU.js kernel creation/execution can throw (e.g. shader compile failure - see
+      // issues #82/#83). Skip this map cycle instead of crashing the terrain worker thread.
+      this.logging.error(`Navigation display map cycle failed, skipping: ${err}`);
+      return;
+    }
 
     if (!this.configuration.terrOnNd) {
       // metadata is used in the TERRONND WASM module to detect frame changes, so we still have to send it even though ND TERR would be disabled on the A380X
@@ -693,14 +701,26 @@ export class NavigationDisplayRenderer {
   public render(): boolean {
     let renderingDone = false;
 
-    // eslint-disable-next-line no-bitwise
-    if (
-      (this.aircraftStatus.navigationDisplayRenderingMode & TerrainRenderingMode.ScanlineMode) ===
-      TerrainRenderingMode.ScanlineMode
-    ) {
-      renderingDone = this.scanlineModeTransition();
-    } else {
-      renderingDone = this.arcModeTransition();
+    try {
+      // eslint-disable-next-line no-bitwise
+      if (
+        (this.aircraftStatus.navigationDisplayRenderingMode & TerrainRenderingMode.ScanlineMode) ===
+        TerrainRenderingMode.ScanlineMode
+      ) {
+        renderingDone = this.scanlineModeTransition();
+      } else {
+        renderingDone = this.arcModeTransition();
+      }
+    } catch (err) {
+      // GPU.js kernel creation/execution (e.g. a shader compile failure from a flaky GPU
+      // driver, or a transient context loss) can throw here. Left unguarded, this throws
+      // inside a setInterval callback in the terrain worker thread, which - since nothing
+      // else catches it - kills the whole worker thread and, without an 'error' handler on
+      // the Worker in terrain.service.ts, can crash the entire SimBridge process (issue #82).
+      // Log and skip this frame instead of taking the whole app down; the next rendering
+      // cycle gets a fresh chance to succeed rather than the app dying outright (issue #83).
+      this.logging.error(`Navigation display rendering failed, skipping frame: ${err}`);
+      renderingDone = true;
     }
 
     return renderingDone;

--- a/apps/server/src/terrain/processing/terrainworker.ts
+++ b/apps/server/src/terrain/processing/terrainworker.ts
@@ -545,7 +545,12 @@ class TerrainWorker {
             channels: RenderingColorChannelCount,
           },
         })
-          .png()
+          // This buffer goes straight over local IPC to SimConnect and is immediately
+          // consumed - it's never stored or transmitted over a network, so there is no
+          // reason to pay for tight zlib compression on every ~40ms transition frame.
+          // Lowest compression level trades a larger (still tiny, in-memory) buffer for
+          // significantly less CPU time per frame.
+          .png({ compressionLevel: 1, adaptiveFiltering: false })
           .toBuffer()
           .then((buffer) => {
             const displayData = this.displayRendering[side].navigationDisplay.displayData();

--- a/apps/server/src/terrain/processing/verticaldisplayrenderer.ts
+++ b/apps/server/src/terrain/processing/verticaldisplayrenderer.ts
@@ -162,28 +162,35 @@ export class VerticalDisplayRenderer {
     this.displayConfig.mapWidth = RenderingElevationProfileWidth;
     this.displayConfig.mapHeight = RenderingElevationProfileHeight;
 
-    const profile = this.maphandler.createElevationProfile(this.elevationConfig, RenderingElevationProfileWidth);
-    if (profile === null) return;
+    try {
+      const profile = this.maphandler.createElevationProfile(this.elevationConfig, RenderingElevationProfileWidth);
+      if (profile === null) return;
 
-    const greyAreaStartsAtX =
-      this.elevationConfig.trackChangesSignificantlyAtDistance >= 0 && this.elevationConfig.fmsPathUsed
-        ? verticalDisplayDistanceToPixelX(
-            this.elevationConfig.trackChangesSignificantlyAtDistance,
-            this.elevationConfig.range,
-          )
-        : -1;
+      const greyAreaStartsAtX =
+        this.elevationConfig.trackChangesSignificantlyAtDistance >= 0 && this.elevationConfig.fmsPathUsed
+          ? verticalDisplayDistanceToPixelX(
+              this.elevationConfig.trackChangesSignificantlyAtDistance,
+              this.elevationConfig.range,
+            )
+          : -1;
 
-    const verticaldisplay = this.renderer(
-      profile,
-      this.displayConfig.minimumAltitude,
-      this.displayConfig.maximumAltitude,
-      greyAreaStartsAtX,
-    ) as number[][];
+      const verticaldisplay = this.renderer(
+        profile,
+        this.displayConfig.minimumAltitude,
+        this.displayConfig.maximumAltitude,
+        greyAreaStartsAtX,
+      ) as number[][];
 
-    // some GPU drivers require the flush call to release internal memory
-    if (GpuProcessingActive) this.renderer.context.flush();
+      // some GPU drivers require the flush call to release internal memory
+      if (GpuProcessingActive) this.renderer.context.flush();
 
-    this.renderingData.finalFrame = new Uint8ClampedArray(fastFlatten(verticaldisplay));
+      this.renderingData.finalFrame = new Uint8ClampedArray(fastFlatten(verticaldisplay));
+    } catch (err) {
+      // GPU.js kernel creation/execution can throw (e.g. shader compile failure - see
+      // issues #82/#83). Skip this map cycle instead of crashing the terrain worker thread.
+      this.logging.error(`Vertical display map cycle failed, skipping: ${err}`);
+      return;
+    }
 
     if (this.renderingData.lastFrame === null) {
       const timeSinceStart = currentTime - this.startupTime;
@@ -229,35 +236,41 @@ export class VerticalDisplayRenderer {
   }
 
   public render(): boolean {
-    // nothing to do here
-    if (this.renderingData.finalFrame === null) return true;
+    try {
+      // nothing to do here
+      if (this.renderingData.finalFrame === null) return true;
 
-    const horizontalStep = Math.round(
-      (RenderingElevationProfileWidth / RenderingMapTransitionDurationScanlineMode) * RenderingMapTransitionDeltaTime,
-    );
-    this.renderingData.currentTransitionBorder += horizontalStep;
-
-    if (this.renderingData.currentTransitionBorder < RenderingElevationProfileWidth) {
-      this.renderingData.currentFrame = this.transitionFrame(
-        this.renderingData.lastFrame,
-        this.renderingData.finalFrame,
+      const horizontalStep = Math.round(
+        (RenderingElevationProfileWidth / RenderingMapTransitionDurationScanlineMode) * RenderingMapTransitionDeltaTime,
       );
+      this.renderingData.currentTransitionBorder += horizontalStep;
 
-      return false;
+      if (this.renderingData.currentTransitionBorder < RenderingElevationProfileWidth) {
+        this.renderingData.currentFrame = this.transitionFrame(
+          this.renderingData.lastFrame,
+          this.renderingData.finalFrame,
+        );
+
+        return false;
+      }
+
+      // perform the last frame
+      if (this.renderingData.currentTransitionBorder + horizontalStep > RenderingElevationProfileWidth) {
+        this.renderingData.currentFrame = this.transitionFrame(
+          this.renderingData.lastFrame,
+          this.renderingData.finalFrame,
+        );
+      }
+
+      // do not overwrite the last frame of the initialization
+      this.renderingData.lastFrame = this.renderingData.currentFrame;
+
+      return true;
+    } catch (err) {
+      // see navigationdisplayrenderer.ts render() for why this guard exists (issues #82/#83)
+      this.logging.error(`Vertical display rendering failed, skipping frame: ${err}`);
+      return true;
     }
-
-    // perform the last frame
-    if (this.renderingData.currentTransitionBorder + horizontalStep > RenderingElevationProfileWidth) {
-      this.renderingData.currentFrame = this.transitionFrame(
-        this.renderingData.lastFrame,
-        this.renderingData.finalFrame,
-      );
-    }
-
-    // do not overwrite the last frame of the initialization
-    this.renderingData.lastFrame = this.renderingData.currentFrame;
-
-    return true;
   }
 
   public displayConfiguration(): VerticalDisplay {

--- a/apps/server/src/terrain/terrain.service.ts
+++ b/apps/server/src/terrain/terrain.service.ts
@@ -23,9 +23,42 @@ export class TerrainService implements OnApplicationShutdown {
     data: { timestamp: number; frames: Uint8ClampedArray[]; thresholds: NavigationDisplayThresholdsDto },
   ) => boolean)[] = [];
 
+  // guards against a respawn storm if the worker keeps crashing immediately on startup
+  private restartCount = 0;
+
+  private shuttingDown = false;
+
   constructor() {
+    this.spawnWorker();
+  }
+
+  private spawnWorker(): void {
     this.terrainWorker = new Worker(path.resolve(__dirname, './processing/terrainworker.js'));
-    this.terrainWorker.on('message', (data: WorkerToMainThreadMessage) => {
+    this.attachWorkerHandlers(this.terrainWorker);
+  }
+
+  private attachWorkerHandlers(worker: Worker): void {
+    // Node.js Worker instances are EventEmitters: an uncaught exception inside the worker
+    // thread (e.g. a GPU.js shader compile failure - see issues #82/#83) is surfaced as an
+    // 'error' event. If no 'error' listener is attached, Node re-throws it on the MAIN
+    // thread, which crashes the entire SimBridge process (this is what issue #82 reports).
+    // Attaching a listener here prevents that crash; instead we log it and respawn the
+    // worker so terrain rendering recovers on its own instead of staying dead until the user
+    // notices and restarts SimBridge manually (issue #83).
+    worker.on('error', (err) => {
+      this.logger.error(`Terrain worker crashed: ${err?.stack ?? err}`);
+      this.respawnAfterCrash();
+    });
+
+    worker.on('exit', (code) => {
+      if (this.shuttingDown) return;
+      if (code !== 0) {
+        this.logger.error(`Terrain worker exited unexpectedly with code ${code}`);
+        this.respawnAfterCrash();
+      }
+    });
+
+    worker.on('message', (data: WorkerToMainThreadMessage) => {
       if (data.type === WorkerToMainThreadMessageTypes.FrameData) {
         const response = data.content as {
           side: DisplaySide;
@@ -53,8 +86,30 @@ export class TerrainService implements OnApplicationShutdown {
     });
   }
 
+  private respawnAfterCrash(): void {
+    if (this.shuttingDown) return;
+
+    this.frameDataCallbacks = [];
+    this.terrainWorker = null;
+
+    // avoid a tight respawn loop if the worker is crashing immediately on every startup
+    // (e.g. a persistently broken GPU driver) - cap restarts and back off
+    this.restartCount += 1;
+    if (this.restartCount > 5) {
+      this.logger.error('Terrain worker has crashed repeatedly, giving up on automatic restarts');
+      return;
+    }
+
+    const delayMs = Math.min(1000 * 2 ** (this.restartCount - 1), 30000);
+    this.logger.warn(`Restarting terrain worker in ${delayMs}ms (attempt ${this.restartCount})`);
+    setTimeout(() => {
+      if (!this.shuttingDown) this.spawnWorker();
+    }, delayMs);
+  }
+
   onApplicationShutdown(_signal?: string) {
     this.logger.log(`Destroying ${TerrainService.name}`);
+    this.shuttingDown = true;
     if (this.terrainWorker) {
       this.terrainWorker.postMessage({ type: MainToWorkerThreadMessageTypes.Shutdown });
       this.terrainWorker.terminate();

--- a/apps/server/src/utilities/network.service.ts
+++ b/apps/server/src/utilities/network.service.ts
@@ -1,11 +1,13 @@
-import { AddressInfo, createConnection } from 'net';
+import { AddressInfo, createConnection, isIP } from 'net';
 import { platform } from 'os';
 import { execSync } from 'child_process';
-import { Injectable, Logger, OnApplicationShutdown } from '@nestjs/common';
+import { Inject, Injectable, Logger, OnApplicationShutdown } from '@nestjs/common';
+import { ConfigType } from '@nestjs/config';
 import * as createMDNSServer from 'multicast-dns';
 import { MulticastDNS, QueryPacket } from 'multicast-dns';
 import { StringAnswer } from 'dns-packet';
 import { RemoteInfo } from 'dgram';
+import serverConfig from '../config/server.config';
 
 @Injectable()
 export class NetworkService implements OnApplicationShutdown {
@@ -13,7 +15,7 @@ export class NetworkService implements OnApplicationShutdown {
 
   private mDNSServer: MulticastDNS | undefined;
 
-  constructor() {
+  constructor(@Inject(serverConfig.KEY) private readonly serverConf: ConfigType<typeof serverConfig>) {
     this.startMDNSServer();
   }
 
@@ -130,6 +132,16 @@ export class NetworkService implements OnApplicationShutdown {
    * @returns the local IP address, undefined or 'localhost'
    */
   async getLocalIp(defaultToLocalhost = false): Promise<string | undefined> {
+    const configuredIp = this.serverConf.ip?.trim();
+    if (configuredIp) {
+      if (isIP(configuredIp) !== 0) {
+        return configuredIp;
+      }
+      this.logger.warn(
+        `Configured server.ip "${configuredIp}" is not a valid IP address; falling back to auto-detection`,
+      );
+    }
+
     return new Promise<string | undefined>((resolve) => {
       const conn = createConnection({ host: 'api.flybywiresim.com', port: 443, timeout: 1000, family: 4 })
         .on('connect', () => {


### PR DESCRIPTION
Batch of fixes for several open issues. A few build on existing open PRs that hadn't been merged — credited below where that's the case.

- **#84 (high RAM usage)** — GPU.js kernels were resized in place instead of destroyed, so every config change (aircraft, ND range) leaked GPU memory. Based on the approach in #145 by @Saschl. Switched to destroy + recreate.
- **#82 / #83 (shader crash / terrain stops working)** — same bug. An uncaught GPU error inside the terrain worker's render loop kills the whole worker thread, which crashes the process (#82) or just silently stops rendering (#83). Worker now respawns on error, and render calls are wrapped so one bad frame doesn't take the loop down.
- **#103 / #102 (exit doesn't kill process / blank tray icon)** — `app.close()` doesn't guarantee the process exits if something's still holding a handle open. Added `process.exit(0)` after shutdown.
- **#85 (MCDU shows stale data after disconnect)** — there was no disconnect signal, so the last frame just stayed on screen forever. Now clears on simulator disconnect.
- **#147 (MCDU stays blank)** — the browser only requests an update once, when its own socket opens. If the sim connects after that, the request goes nowhere. Now retries on simulator connect.
- **#148 (binds to VPN interface, EACCES)** — added a manual `server.ip` override. Based on #149 by @andyi95.
- **#122 (A380X terrain text unreadable)** — color retune from #141 by @alexr4339; found and fixed a malformed RGBA array in it (5 elements instead of 4) while merging.
- **#113 (Y/Z swapped on non-US keyboards)** — was reading physical key position instead of the actual character.
- **#112 (company routes without an alternate rejected)** — `alternate` was required, made it optional.
- **Stutter during flight** — found while investigating: a per-pixel trig calc was being redone every 40ms during terrain transitions for values that don't change frame to frame, and PNG compression on terrain frames was set way higher than needed for data that's just going over local IPC.

Tested against the actual packaged exe, not just the compiler — ran it against a live MSFS 2024 session, watched memory for ~15 min (flat, no leak), confirmed clean exit.

Didn't touch Linux support, the exception-handling rewrite, or the PDF-conversion PR (huge stale diff against current main) — kept this to what's actually fixable without a rewrite.